### PR TITLE
Review Quote cleaning process

### DIFF
--- a/src/banners.css
+++ b/src/banners.css
@@ -25,10 +25,10 @@
 }
 
 /* Banner */
-body:is([data-page="page"], [data-page="home"]).is-banner-active #banner {
+body:is([data-page="page"], [data-page="home"], [data-page="all-journals"]).is-banner-active #banner {
     height: var(--bannerHeight);
 }
-body:is([data-page="page"], [data-page="home"]).is-banner-active #banner::before {
+body:is([data-page="page"], [data-page="home"], [data-page="all-journals"]).is-banner-active #banner::before {
     position: absolute;
     top: 0;
     right: 0;
@@ -43,6 +43,7 @@ body:is([data-page="page"], [data-page="home"]).is-banner-active #banner::before
 
 /* Icon */
 body[data-page="home"].is-icon-active .journal-item:first-of-type>.page>.flex-col:first-child>.content>.flex-1::before,
+body[data-page="all-journals"].is-icon-active .journal-item:first-of-type>.page>.flex-col:first-child>.content>.flex-1::before,
 body[data-page="page"].is-icon-active .page>.relative>.flex-row>.flex-1::before {
     content: var(--pageIcon);
     font-size: var(--iconWidth);
@@ -55,22 +56,26 @@ body[data-page="page"].is-icon-active .page>.relative>.flex-row>.flex-1::before 
     opacity: 0.9;
 }
 body[data-page="home"].is-icon-active #main-content-container .journal-item:first-of-type .journal-title,
+body[data-page="all-journals"].is-icon-active #main-content-container .journal-item:first-of-type .journal-title,
 body[data-page="page"].is-icon-active #main-content-container .page-title,
 body[data-page="page"].is-icon-active #main-content-container .ls-page-title.editing {
     margin-top: 35px;
 }
-body[data-page="home"].is-icon-active #journals .journal-item:first-child {
+body[data-page="home"].is-icon-active #journals .journal-item:first-child,
+body[data-page="all-journals"].is-icon-active #journals .journal-item:first-child {
     margin-top: 0;
 }
 
 /* Small icons for other home journal items */
-body[data-page="home"].is-icon-active #journals .journal-item h1.title::before {
+body[data-page="home"].is-icon-active #journals .journal-item h1.title::before,
+body[data-page="all-journals"].is-icon-active #journals .journal-item h1.title::before {
     content: var(--pageIcon);
     margin-right: 8px;
     font-size: 0.9em;
     font-weight: normal;
 }
-body[data-page="home"].is-icon-active #journals .journal-item:first-of-type h1.title::before {
+body[data-page="home"].is-icon-active #journals .journal-item:first-of-type h1.title::before,
+body[data-page="all-journals"].is-icon-active #journals .journal-item:first-of-type h1.title::before {
     display: none;
 }
 .is-icon-active #main-content-container .page-title .page-icon {

--- a/src/banners.ts
+++ b/src/banners.ts
@@ -841,7 +841,7 @@ const getRandomQuote = async () => {
   // Delete mark
   quoteHTML = quoteHTML.replace(/(==)|(\^\^)/g, "");
   // Add Markdown bold & italic to HTML
-  quoteHTML = quoteHTML.replace(/\*\*(.*)\*\*/g, "<b>$1</b>").replace(/\*(.*)\*/g, "<i>$1</i>").replace(/_(.*)_/g, "<i>$1</i>");
+  quoteHTML = quoteHTML.replace(/\*\*(.*?)\*\*/g, "<b>$1</b>").replace(/\*(.*?)\*/g, "<i>$1</i>").replace(/_(.*?)_/g, "<i>$1</i>");
   // Keep lines breaks
   quoteHTML = quoteHTML.replaceAll("\n", "<br/>");
   

--- a/src/banners.ts
+++ b/src/banners.ts
@@ -162,7 +162,7 @@ const settingsArray: SettingSchemaDesc[] = [
     title: "Cleanup RegEx for quote text",
     description: "",
     type: "string",
-    default: "(^(TODO|NOW))|(id::.*)|(SCHEDULED:.<.*>)",
+    default: "(^(TODO|NOW))|([a-z-]+::.*)|(SCHEDULED:.<.*>)|(\[\[)|(\]\])",
   },
   {
     key: "widgetsCustomHeading",
@@ -456,7 +456,7 @@ const getPageType = () => {
   isPage = false;
   isHome = false;
   const pageType = body.getAttribute("data-page");
-  if (pageType === "home") {
+  if (pageType === "home" || pageType === "all-journals") {
     isHome = true;
     isPage = false;
   }
@@ -835,7 +835,7 @@ const getRandomQuote = async () => {
   let quoteHTML = randomQuoteBlock[0];
   // Delete searched tag
   const regExpTag = new RegExp(`${widgetsConfig.quote.tag}`,"gi");
-  quoteHTML = quoteHTML.replace(regExpTag, "").replace(/\n/g, "").trim();
+  quoteHTML = quoteHTML.replace(regExpTag, "").trim();
   // Cleanup
   const regExpCleanup = new RegExp(`${widgetsConfig.quote.cleanup}`,"g");
   quoteHTML = quoteHTML.replace(regExpCleanup, "").trim();
@@ -843,6 +843,9 @@ const getRandomQuote = async () => {
   quoteHTML = quoteHTML.replace(/(==)|(\^\^)/g, "");
   // Add Markdown bold & italic to HTML
   quoteHTML = quoteHTML.replace(/\*\*(.*)\*\*/g, "<b>$1</b>").replace(/\*(.*)\*/g, "<i>$1</i>").replace(/_(.*)_/g, "<i>$1</i>");
+  // Keep lines breaks
+  quoteHTML = quoteHTML.replace("\n", "<br/>");
+  
   const pageTitle = randomQuoteBlock[1];
   const pageURL = encodeURI(`logseq://graph/${currentGraph?.name}?page=${pageTitle}`);
   quoteHTML = `<a href=${pageURL} title="${pageTitle}" id="banner-widgets-quote-link">${quoteHTML}</a>`;


### PR DESCRIPTION
* Fix bug #60: Missing banner rendering when `Journals` button pressed instead of `Home`
* Quote cleaning: Remove all properties, not only `id::`
* Quote cleaning: Keep line breaks to preserve original quote formatting
* Quote cleaning: Remove double brackets (`[[` and `]]`)
* Quote cleaning: Remove all hashtags
* Quote cleaning: Disable greedy mode for markdown regex (probably bug #60)
* Improve quote search: Now widget can find all qoutes for tag (not only starting and ending with tag)
* Clicking to quote: Change link to exact block with quote