### PR TITLE
Local urls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .DS_Store
 dist
 *.local
+*.sublime-*

--- a/src/banners.ts
+++ b/src/banners.ts
@@ -65,8 +65,8 @@ const widgetsQuoteCleanupRegExps: RegExp[] = [
   /\nSCHEDULED:.<[^>]+>/g,
   /\[\[/g,
   /\]\]/g,
-  /#[^ ]+/g,
-  /#\[\[[^\]]+\]\]/g,
+  /#[^ #\n]+/g,
+  /#\[\[[^\]\n]+\]\]/g,
   /==/g,
   /\^\^/g,
 ];


### PR DESCRIPTION
## ⚠️ Finally fixed (these tasks can be closed):
* #61
* #60
* #58 

## Additional
* Dropped Command Palette command "Rebuild Regex for Banner Plugin" — it doesn't work anyway
* Taken off from plugin settings `widgetsQuoteCleanupRegExp` — it is too tech option (not intended for users)
* Quote cleaning process reviewed and generalised
* Added new step to quote cleaning process: handle refs in form `((blockUUID))`
* Dropped some debug console outputs and some moved to debug level
* Fix bug when handling local urls to default banners for journals and pages — `assets://` changed to `file://`
* Remove obvious comments
